### PR TITLE
fixes to missing on-page 1st-level headings

### DIFF
--- a/01-overview/index.md
+++ b/01-overview/index.md
@@ -2,11 +2,13 @@
 [tags]: # (,)
 [priority]: # (1100)
 
+# Overview
+
 DevOps Secrets Vault (DSV) offers a cross-platform solution for command-line and scripted access to secrets stored in a hosted Secret Server vault.
 
 * You can directly operate DSV from the command line, entering DSV commands and observing the Secret Server responses in real time.
 
-    This can make it easier to resolve Help Desk cases involving Secret Server issues affecting specific users or applicatios.
+  This can make it easier to resolve Help Desk cases involving Secret Server issues affecting specific users or applicatios.
 
 * You can deploy DSV as command sequences (scripts) within a machine image or application container.
 

--- a/02-download/index.md
+++ b/02-download/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (1200)
 
+# Download and Install DSV
+
 Setting up DSV requires only a few steps.
 
 ## Download the Executable for Your OS

--- a/03-config-basic/index.md
+++ b/03-config-basic/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (3000)
 
+# Configure DSV • Basics
+
 Knowing how DSV stores its settings makes DSV configuration work straightforward. 
 
 ## Configs and Profiles

--- a/04-config-advanced/10-add-profile.md
+++ b/04-config-advanced/10-add-profile.md
@@ -1,6 +1,8 @@
 ﻿[title]: # (Add a Profile to a Config)
 [tags]: # (,)
 [priority]: # (4010)
+
+## Add a Profile to a Config
  
 On initial configuration, DSV will have a config with just one profile.
 
@@ -20,7 +22,7 @@ Assuming `thy init` succeeds, DSV will append the profile to the config. To outp
 
 `thy cli-config read`
 
-### Using an Alternate Profile for Most CLI Actions
+## Using an Alternate Profile for Most CLI Actions
 
 `thy secret read --path mysecret --profile developer`
 

--- a/04-config-advanced/index.md
+++ b/04-config-advanced/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (4000)
 
+# Configure DSV • Advanced
+
 The `thy init` command without flags produces a default DSV config. A custom config offers more control, allowing you to:
 
 * choose how DSV stores credentials

--- a/05-cli-overview/index.md
+++ b/05-cli-overview/index.md
@@ -2,6 +2,10 @@
 [tags]: # (,)
 [priority]: # (5000)
 
+# CLI Overview
+
+Like most CLI applications, DSV combines a base collection of commands and their parameters with a selection of flags to deliver a task-focused toolset.
+
 ## DSV Command Syntax
 
 DSV commands follow a simple syntax:

--- a/06-cli-examples/index.md
+++ b/06-cli-examples/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (6000)
 
+# CLI Examples
+
 A secret is any sensitive information you want to store in a Secret Server vault. Common secrets include passwords, SSH keys, and SSL certificates, but a secret can be anything represented as a file on computer media.
 
 Secrets are identified by a path, which lets you organize your vault and define access permissions.

--- a/07-cli-ref/01-secrets.md
+++ b/07-cli-ref/01-secrets.md
@@ -2,11 +2,13 @@
 [tags]: # (,)
 [priority]: # (7010)
 
+## Secrets
+
 Secrets are sensitive data protected by Secret Server. Many secrets relate to authentication—such as passwords, SSH keys, and SSL certificates—but secrets can be anything represented as a file on computer storage media.
 
 When DSV has possession of secrets outside the Secret Server Vault, it keeps them encrypted and locked down in conformance to the specific permissions and policies in the config.
 
-## Available Commands
+### Available Commands
 
 | Command | Action |
 | ----- | ----- |

--- a/07-cli-ref/02-users.md
+++ b/07-cli-ref/02-users.md
@@ -2,15 +2,17 @@
 [tags]: # (,)
 [priority]: # (7020)
 
+## Users
+
 For DSV, the term “users” refers to security principals in the vault that can authenticate locally by a username and password or can authenticate through a federated provider such as AWS or ARN.
 
-## Understanding Qualified Usernames
+### Understanding Qualified Usernames
 
 When a user or role ties to a third-party provider, the name will be the fully qualified name to help distinguish potentially duplicate user or role names across different systems.
 
 The name qualifier format `provider name:local name` means for example that the _test-admin_ user will have the username _aws-dev:test-admin_ while the local user with username _test-admin_ will not have a qualifier, so its username will just be _test-admin_.
 
-## Available Commands
+### Available Commands
 
 | Command | Action |
 | ----- | ----- |
@@ -25,6 +27,7 @@ The name qualifier format `provider name:local name` means for example that the 
 
 The create command takes several `--parameters` that spec foundational aspects of the user record.
 
+| Parameter | Content |
 | ----- | ----- |
 | --username | local username; required; supports local authentication by username and password; need not match that used by a federated authentication provider (if present) |
 | --password | password for local authentication by username and password |

--- a/07-cli-ref/03-roles.md
+++ b/07-cli-ref/03-roles.md
@@ -2,9 +2,11 @@
 [tags]: # (,)
 [priority]: # (7030)
 
+## Roles
+
 With DSV, the term “roles” describes security principals in the vault that tie to third-party providers or client credentials for granting permissions.
 
-## Available Commands
+### Available Commands
 
 | Command | Action |
 | ----- | ----- |
@@ -20,6 +22,7 @@ With DSV, the term “roles” describes security principals in the vault that t
 
 The create command takes several `--parameters` that spec key aspects of the role record.
 
+| Parameter | Content |
 | ----- | ----- |
 | --desc | description of the role |
 | --name | name of the role |

--- a/07-cli-ref/04-clients.md
+++ b/07-cli-ref/04-clients.md
@@ -2,9 +2,11 @@
 [tags]: # (,)
 [priority]: # (7040)
 
+## Clients
+
 Client credentials enable applications to authenticate as the role assigned to the client record.
 
-## Available Commands
+### Available Commands
 
 | Command | Action |
 | ----- | ----- |

--- a/07-cli-ref/05-configuration.md
+++ b/07-cli-ref/05-configuration.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (7050)
 
+# Configurations
+
 Paths record the filesystem locations of executables. The configuration for DevOps Secrets Vault
 
 * defines paths and permissions for paths within the application, and
@@ -86,14 +88,14 @@ tenantName: example
 ```
 
 The `permissionDocument` lists policies that define a subject’s access to a certain resource path. The syntax supports wildcards via the `<.*>` construct.
-
------ | -----
-actions | a list of possible actions on the resource (create, read, update, delete, list, share, assign)
-conditions | an optional CIDR range to lock down access to a specific IP range
-description | human friendly description of the policy intent
-effect | whether the policy is allowing or preventing access; valid values are: `allow`, `deny`
-id | system-generated unique identifier to track changes to a particular policy
-resources | the resource path defining the entities to which the permissions apply; a resource path prefixes the entity type (`secrets, clients, roles, users`) to a colon delimited path to the resource.
+| Element | Definition |
+|----- | ----- |
+| actions | a list of possible actions on the resource (create, read, update, delete, list, share, assign) |
+| conditions | an optional CIDR range to lock down access to a specific IP range |
+| description | human friendly description of the policy intent |
+| effect | whether the policy is allowing or preventing access; valid values are: `allow`, `deny` |
+| id | system-generated unique identifier to track changes to a particular policy |
+| resources | the resource path defining the entities to which the permissions apply; a resource path prefixes the entity type (`secrets, clients, roles, users`) to a colon delimited path to the resource. |
 
 ### Policy Evaluation
 

--- a/07-cli-ref/index.md
+++ b/07-cli-ref/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (7000)
 
+# CLI Reference
+
 The common subjects of DSV CLI commands include:
 
 * secrets

--- a/08-authent-gen/index.md
+++ b/08-authent-gen/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (8000)
 
+# Authentication • General
+
 As noted in **Configure DSV: Advanced**, DSV supports several authentication methods, potentially easing cloud deployments by tapping in-place authentication providers such as AWS and Azure.
 
 ## Types of Authentication

--- a/09-authent-other/index.md
+++ b/09-authent-other/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (9000)
 
+# Authentication • Azure or AWS
+
 Edit the DSV configuration by running config edit, which opens up a default editor such as nano in most linux shells, on save the configuration will be automatically updated in vault.
 
 !!! note "Secret Permissions" On Windows you must read the config, save it as a file, edit locally, and then run the config update command. The config edit command is only available on Linux and Mac currently.

--- a/10-bestpracts/index.md
+++ b/10-bestpracts/index.md
@@ -2,5 +2,7 @@
 [tags]: # (,)
 [priority]: # (10000)
 
+# Best Practices
+
 no content yet exists for this page
 

--- a/11-extensions/01-jenkins.md
+++ b/11-extensions/01-jenkins.md
@@ -2,6 +2,9 @@
 [tags]: # (,)
 [priority]: # (11010)
 
+## Jenkins
+
+
 ### Obtain
 
 

--- a/11-extensions/02-kubernetes.md
+++ b/11-extensions/02-kubernetes.md
@@ -2,6 +2,9 @@
 [tags]: # (,)
 [priority]: # (11020)
 
+## Kubernetes
+
+
 ### Obtain
 
 

--- a/11-extensions/03-dsvjavasdk.md
+++ b/11-extensions/03-dsvjavasdk.md
@@ -2,6 +2,9 @@
 [tags]: # (,)
 [priority]: # (11030)
 
+## DSV Java SDK
+
+
 ### Obtain
 
 

--- a/11-extensions/index.md
+++ b/11-extensions/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (11000)
 
+DSV Extensions
+
 DSV extensions support its use with other tools. Currently, we offer two extensions.
 
 * Our [Jenkins](.\01-jenkins.htm) extension supports shops using Jenkins for continuous integration.

--- a/12-quickref/index.md
+++ b/12-quickref/index.md
@@ -2,4 +2,6 @@
 [tags]: # (,)
 [priority]: # (12000)
 
+# CLI Quick Reference
+
 content to be derived from the list of commands and the API reference

--- a/13-relnotes/index.md
+++ b/13-relnotes/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (13000)
 
+# Release Notes
+
 content to be developed from a draft by B. VanCannon
 
 

--- a/index.md
+++ b/index.md
@@ -2,6 +2,8 @@
 [tags]: # (,)
 [priority]: # (1000)
 
+#Welcome to the DSV Tech Doc Depot
+
 Welcome to Thycotic’s Tech Doc Depot for DevOps Secrets Vault. If it relates to DSV, you will find it here.
 
 * The navigation panel at left sequences topics for new customers. Browsing this resource like a book fosters a solid technical grounding in DevOps Secrets Vault.


### PR DESCRIPTION
on-page 1st-level headings were missing due to a misconception of how Homer works vs. Mkdocs regarding the origins of headings in the navigation and in the body