### PR TITLE
pervasive link error corrected

### DIFF
--- a/product/03-setup/index.md
+++ b/product/03-setup/index.md
@@ -113,7 +113,7 @@ Select `(3) AWS IAM (federated)` to authenticate as a trusted Identity Access Ma
 
 Select `(4) Azure (federated)` to authenticate as a trusted Azure Managed Service Identity  (MSI).
 
-The [Authentication: General](..\04-authent-gen\index.md) and [Authentication: Azure or AWS](..\05-authent-azure-aws\index.md) provide details for each of these choices. 
+The [Authentication: General](..\04-authent-gen\index.htm) and [Authentication: Azure or AWS](..\05-authent-azure-aws\index.htm) provide details for each of these choices. 
 
 Finally, the initialization process will prompt about the **cache strategy for secrets**. The choice here depends on your specific set of concerns around security, network connectivity, performance, and systems availability.
 
@@ -137,5 +137,5 @@ Please enter cache strategy for secrets:
 
 Selecting the cache strategy completes setup. You can begin using the DevOps Secrets Vault Command Line Interface to administer secrets in your organization’s secure cloud-hosted secrets vault.
 
-The [Commands Overview](..\06-cli-overview\index.md), [Commands Examples](..\07-cli-examples\index.md), and [CLI Reference](..\08-cli-ref\index.md) will get you started.
+The [Commands Overview](..\06-cli-overview\index.htm), [Commands Examples](..\07-cli-examples\index.htm), and [CLI Reference](..\08-cli-ref\index.htm) will get you started.
 

--- a/product/04-authent-gen/index.md
+++ b/product/04-authent-gen/index.md
@@ -4,7 +4,7 @@
 
 # Authentication: General
 
-As noted in [Setup DevOps Secrets Vault](..\03-setup\index.md), DSV supports several authentication methods, potentially easing cloud deployments by tapping in-place authentication providers such as AWS and Azure.
+As noted in [Setup DevOps Secrets Vault](..\03-setup\index.htm), DSV supports several authentication methods, potentially easing cloud deployments by tapping in-place authentication providers such as AWS and Azure.
 
 ## Types of Authentication
 
@@ -44,7 +44,7 @@ Password authentication relies directly on individual user accounts. Routine act
 
 * adding the new user to the DSV config
 
-See the [Users](..\08-cli-ref\02-users.md) portion of the CLI Reference for details.
+See the [Users](..\08-cli-ref\02-users.htm) portion of the CLI Reference for details.
 
 ### Client Credentials
 
@@ -60,10 +60,10 @@ Routine activities associated with this authentication method include:
 
 * invoking the `init` command and supplying those client credentials
 
-See the [Roles](..\08-cli-ref\03-roles.md) portion of the CLI Reference for more information.
+See the [Roles](..\08-cli-ref\03-roles.htm) portion of the CLI Reference for more information.
 
 ### Third Party Authentication
 
-Authentication through Azure or AWS requires additional setup steps so that DSV has information about trusted accounts, users, and roles and the permissions assigned to each. The [Authentication: Azure or AWS](..\05-authent-azure-aws\index.md) section covers this in detail. 
+Authentication through Azure or AWS requires additional setup steps so that DSV has information about trusted accounts, users, and roles and the permissions assigned to each. The [Authentication: Azure or AWS](..\05-authent-azure-aws\index.htm) section covers this in detail. 
 
 

--- a/product/05-authent-azure-aws/index.md
+++ b/product/05-authent-azure-aws/index.md
@@ -109,7 +109,7 @@ When you create a user in AWS, remember that the username serves as a friendly n
 thy user create --username test-admin --external-id arn:aws:iam::00000000000:user/test-admin --provider aws-dev
 ```
 
-After creating the user, modify the config to give that user access to the default administrator permission policy. For details on limiting access to specific paths, see the [Permissions](../08-cli-ref/06-permissions.md) section of the [CLI Reference](../08-cli-ref/index.md).
+After creating the user, modify the config to give that user access to the default administrator permission policy. For details on limiting access to specific paths, see the [Permissions](../08-cli-ref/06-permissions.htm) section of the [CLI Reference](../08-cli-ref/index.htm).
 
 ```bash
 thy config edit --encoding yaml
@@ -253,7 +253,7 @@ thy user create --username test-api --provider azure-prod --external-id /subscri
  
 ```
 
-Modify the config to give that user access to the default administrator permission policy. For details on limiting access to specific paths see the [Permissions](../08-cli-ref/06-permissions.md) section of the [CLI Reference](../08-cli-ref/index.md).
+Modify the config to give that user access to the default administrator permission policy. For details on limiting access to specific paths see the [Permissions](../08-cli-ref/06-permissions.htm) section of the [CLI Reference](../08-cli-ref/index.htm).
 
 ```bash
 thy config edit --encoding yaml
@@ -310,7 +310,7 @@ If you want to grant access to a set of VM’s in a resource group that use a sy
 thy role create --name identity-rg --provider azure-prod --external-id /subscriptions/216d58f0-9fa1-49fa-b1f6-81e9f8a12f82/resourceGroups/build
 ```
 
-Modify the config to give that role access to the default administrator permission policy. For details on limiting access to specific paths see the [Permissions](../08-cli-ref/06-permissions.md) section of the [CLI Reference](../08-cli-ref/index.md).
+Modify the config to give that role access to the default administrator permission policy. For details on limiting access to specific paths see the [Permissions](../08-cli-ref/06-permissions.htm) section of the [CLI Reference](../08-cli-ref/index.htm).
 
 ```bash
 thy config edit --encoding yaml

--- a/product/08-cli-ref/05-configuration.md
+++ b/product/08-cli-ref/05-configuration.md
@@ -49,7 +49,7 @@ permissionDocument:
   effect: allow
 ```
 
-For more details about how DVS works with permissions, see the [Permissions](.\06-permissions.md) article.
+For more details about how DVS works with permissions, see the [Permissions](.\06-permissions.htm) article.
 
 { *for the entirety of the content under the following two headings, I am way out on a limb; this is essentially placeholder material consistent in form with the doc for other entities such as `user` or `role`, but no inputs for such were evident, so this is improvised--it requires correction* }
 

--- a/product/index.md
+++ b/product/index.md
@@ -6,15 +6,15 @@
 
 This technical documentation collection for DevOps Secrets Vault includes short, topically focused, technically oriented material, including product descriptions, diagrams, instructions, general guidance, and reference content.
 
-See the [Overview](./01-overview/index.md) for basics, and [Obtain DSV](./02-obtain/index.md) for information about trying out the product.
+See the [Overview](./01-overview/index.htm) for basics, and [Obtain DSV](./02-obtain/index.htm) for information about trying out the product.
 
-[Setup](./03-setup/index.md) explains initial setup steps. Authentication figures prominently— [Authentication: General](.\04-authent-gen\index.md) covers typical installations, while [Authentication: Azure or AWS](.\05-authent-azure-aws\index.md) covers use of DSV with third party authentication platforms.
+[Setup](./03-setup/index.htm) explains initial setup steps. Authentication figures prominently— [Authentication: General](.\04-authent-gen\index.htm) covers typical installations, while [Authentication: Azure or AWS](.\05-authent-azure-aws\index.htm) covers use of DSV with third party authentication platforms.
 
-The CLI [Overview](./06-cli-overview/index.md), [Examples](./07-cli-examples/index.md), and [Reference](./08-cli-ref/index.md) sections pin out the details of using DevOps Secrets Vault.
+The CLI [Overview](./06-cli-overview/index.htm), [Examples](./07-cli-examples/index.htm), and [Reference](./08-cli-ref/index.htm) sections pin out the details of using DevOps Secrets Vault.
 
-The [Release Notes](./11-relnotes/index.md) provide late-breaking information, and [Customer Support Resources](./12-cust-support/index.md) connects you to available support resources.
+The [Release Notes](./11-relnotes/index.htm) provide late-breaking information, and [Customer Support Resources](./12-cust-support/index.htm) connects you to available support resources.
 
-Related documents include those about the [Jenkins](..\extensions\jenkins\index.md) and[Kubernetes](..\extensions\kubernetes\index.md) extensions and the [DSV Java SDK](..\sdk\java\index.md).
+Related documents include those about the [Jenkins](..\extensions\jenkins\index.htm) and[Kubernetes](..\extensions\kubernetes\index.htm) extensions and the [DSV Java SDK](..\sdk\java\index.htm).
 
 ---
 
@@ -22,15 +22,15 @@ Related documents include those about the [Jenkins](..\extensions\jenkins\index.
 
 DSV extensions support its use with other tools. Currently, Thycotic offers two extensions.
 
-* The [Jenkins](..\extensions\jenkins\index.md) extension supports shops using Jenkins for continuous integration.
+* The [Jenkins](..\extensions\jenkins\index.htm) extension supports shops using Jenkins for continuous integration.
 
-* The [Kubernetes](..\extensions\kubernetes\index.md) extension supports organizations using Kubernetes to manage containerized applications.
+* The [Kubernetes](..\extensions\kubernetes\index.htm) extension supports organizations using Kubernetes to manage containerized applications.
 
 Extensions expected in future DSV releases include Puppet, OpenShift, Chef, Ansible, and Salt, among others.
 
 ## Java SDK for DevOps Secrets Vault
 
-Additionally, for customers interested in creating their own extensions to integrate DSV into their infrastructure, we provide the [DSV Java SDK](..\sdk\java\index.md).
+Additionally, for customers interested in creating their own extensions to integrate DSV into their infrastructure, we provide the [DSV Java SDK](..\sdk\java\index.htm).
 
 ## DevOps Secrets Vault API Documentation
 


### PR DESCRIPTION
a briefly present pervasive in-body-text-only link error related to having prepped for a Plan B with MkDocs has been corrected