### PR TITLE
correct link to API on the one page where it was wrong

### DIFF
--- a/product/index.md
+++ b/product/index.md
@@ -36,4 +36,4 @@ The [Customer Support Resources](./11-cust-support/index.md) article connects yo
 
 Related documents (button above articles menu) include those about the [Jenkins](../extensions/jenkins/index.md) and [Kubernetes](../extensions/kubernetes/index.md) extensions and the [DSV Java SDK](../sdk/java/index.md).
 
-Thycotic also provides in a separate location a full [API Reference](dsv.thycotic.com/api) for DevOps Secrets Vault.
+Thycotic also provides in a separate location a full [API Reference](https://dsv.thycotic.com/api) for DevOps Secrets Vault.


### PR DESCRIPTION
on top level index page it was improperly abbreviated to not have the https:// so it was failing in Angular JS to be treated as different from a relative link