### PR TITLE
remove redundant sentence

### DIFF
--- a/product/01-overview/architecture.md
+++ b/product/01-overview/architecture.md
@@ -42,9 +42,6 @@ hours with a target of 20 minutes.
 
 ## Disaster Recovery
 
-In the event of a disaster such as an AWS region failing, we would have to
-rebuild using AMI/CloudFormation files and deploy in a new region.
-
 For the DSV application, the broadest scale of consequence for a disaster would
 be equivalent to an AWS region failing. That would cause complete loss of access
 to Thycotic’s cloud entities located in the failed region for an indefinite,

--- a/product/05-authent-azure-aws/index.md
+++ b/product/05-authent-azure-aws/index.md
@@ -181,7 +181,7 @@ This example assumes that you:
 * have your own thy CLI configured locally with an admin account
 * created an IAM role in the AWS Console
 * launched an EC2 instance using the IAM role
-* [downloaded](https://downloads.lvc.thycotic.com) the thy CLI onto the EC2 instance
+* [downloaded](https://dsv.thycotic.com/downloads) the thy CLI onto the EC2 instance
 
 Create a corresponding role in DSV with the external-id of the IAM role's ARN.
 


### PR DESCRIPTION
in the disaster recovery portion of architecture page, removed a sentence that was originally introductory, but after edits to sentences after it, had become redundant